### PR TITLE
Feat/records

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     DOCS_URL: str = "/api/docs"
     REDOC_URL: str = "/api/redoc"
     
-    VIDEO_STORAGE_PATH: str = "static/video"
-    VIDEO_UPLOAD_DIR: str = "uploads"
+    VIDEO_STORAGE_PATH: str = "static/video"  # 원본 비디오 저장 경로
+    RECORD_STORAGE_PATH: str = "static/record"  # 이벤트 영상과 썸네일 저장 경로
     ALLOWED_VIDEO_TYPES: List[str] = ["video/mp4", "video/x-msvideo", "video/quicktime"]
     MAX_VIDEO_SIZE: int = 100 * 1024 * 1024  # 100MB
     

--- a/server/database.py
+++ b/server/database.py
@@ -1,24 +1,28 @@
 # server/database.py
-# SQLAlchemy 데이터베이스 설정
-# - SQLite 데이터베이스 연결
+# SQLAlchemy를 사용한 데이터베이스 연결 및 세션 관리
+# - 데이터베이스 엔진 생성
 # - 세션 관리
-# - 기본 모델 클래스 정의
+# - 데이터베이스 초기화
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 import json
 from pathlib import Path
+from config import settings
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./database.db"
-
+# SQLAlchemy 엔진 생성
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    settings.SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
+
+# 세션 생성
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
+# Base 클래스 생성
 Base = declarative_base()
 
+# 데이터베이스 세션 의존성
 def get_db():
     db = SessionLocal()
     try:
@@ -70,7 +74,4 @@ def initialize_database():
         print(f"데이터베이스 초기화 중 오류 발생: {str(e)}")
         db.rollback()
     finally:
-        db.close()
-
-# 서버 시작 시 DB 초기화
-initialize_database() 
+        db.close() 

--- a/server/main.py
+++ b/server/main.py
@@ -5,10 +5,11 @@
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 
 from config import settings
-from database import engine, Base, get_db
+from database import engine, Base, get_db, initialize_database
 from routers import records as record_router
 from routers import websockets as websocket_router
 from routers import lives as live_router
@@ -38,6 +39,9 @@ app = FastAPI(
     swagger_ui_parameters={"defaultModelsExpandDepth": -1}
 )
 
+# 정적 파일 서빙 설정
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
 # CORS 설정
 app.add_middleware(
     CORSMiddleware,
@@ -59,6 +63,9 @@ async def startup_event():
     Base.metadata.create_all(bind=engine)
     print("Database tables created successfully.")
     
+    # 데이터베이스 초기화 (메타데이터 로드)
+    initialize_database()
+
     print(f"Application startup complete. YOLO model loaded: {settings.YOLO_MODEL_PATH}")
     if not settings.GEMINI_API_KEY:
         print("Warning: GEMINI_API_KEY is not set in .env file or config.")

--- a/server/main.py
+++ b/server/main.py
@@ -17,9 +17,9 @@ from websocket_manager import connection_manager
 # 개발용: 데이터베이스 테이블 재생성
 # print("Dropping all tables for recreation...")
 # Base.metadata.drop_all(bind=engine)
-print("Creating database tables...")
-Base.metadata.create_all(bind=engine)
-print("Database tables created successfully.")
+# print("Creating database tables...")
+# Base.metadata.create_all(bind=engine)
+# print("Database tables created successfully.")
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
@@ -54,6 +54,11 @@ app.include_router(websocket_router.router, tags=["WebSockets"])
 
 @app.on_event("startup")
 async def startup_event():
+    # 데이터베이스 테이블 생성
+    print("Creating database tables...")
+    Base.metadata.create_all(bind=engine)
+    print("Database tables created successfully.")
+    
     print(f"Application startup complete. YOLO model loaded: {settings.YOLO_MODEL_PATH}")
     if not settings.GEMINI_API_KEY:
         print("Warning: GEMINI_API_KEY is not set in .env file or config.")

--- a/server/models.py
+++ b/server/models.py
@@ -36,6 +36,8 @@ class FireEvent(Base):
     event_type = Column(String)
     confidence = Column(Float, nullable=True)
     analysis = Column(String, nullable=True)
+    file_path = Column(String, nullable=True)  # 저장된 영상 파일 경로
+    thumbnail_path = Column(String, nullable=True)  # 썸네일 이미지 경로
 
     video = relationship("Video", back_populates="events")
 

--- a/server/routers/lives.py
+++ b/server/routers/lives.py
@@ -23,7 +23,7 @@ async def stream_video_realtime(video_id: str, db: Session = Depends(get_db)):
     video_path = f"{settings.VIDEO_STORAGE_PATH}/{video.id}.mp4"
     print(f"Attempting to stream video from: {video_path}")
     return StreamingResponse(
-        VideoProcessingService.frame_generator_with_yolo(video_path), 
+        VideoProcessingService.frame_generator_with_yolo(video_path, video_id), 
         media_type="multipart/x-mixed-replace; boundary=frame"
     )
 

--- a/server/routers/lives.py
+++ b/server/routers/lives.py
@@ -19,11 +19,8 @@ async def stream_video_realtime(video_id: str, db: Session = Depends(get_db)):
     if not video:
         raise HTTPException(status_code=404, detail="Video not found")
     
-    # 비디오 파일 경로
-    video_path = f"{settings.VIDEO_STORAGE_PATH}/{video.id}.mp4"
-    print(f"Attempting to stream video from: {video_path}")
     return StreamingResponse(
-        VideoProcessingService.frame_generator_with_yolo(video_path, video_id), 
+        VideoProcessingService.frame_generator_with_yolo(video_id),
         media_type="multipart/x-mixed-replace; boundary=frame"
     )
 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -26,6 +26,8 @@ class FireEvent(BaseModel):
     event_type: str
     confidence: Optional[float] = None
     analysis: Optional[str] = None
+    file_path: Optional[str] = None
+    thumbnail_path: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -53,6 +55,7 @@ class EventDetail(BaseModel):
     address: str
     timestamp: datetime
     video_url: str
+    thumbnail_url: str
     description: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/server/services.py
+++ b/server/services.py
@@ -38,9 +38,14 @@ class VideoProcessingService:
         return file_path
 
     @staticmethod
-    async def frame_generator_with_yolo(video_path: str):
+    async def frame_generator_with_yolo(video_path: str, cctv_id: str):
         """
         주어진 영상 파일 경로를 통해 프레임을 읽고, YOLO 검증 후 마킹된 프레임을 생성하여 yield 합니다.
+        영상이 끝나면 자동으로 처음부터 다시 재생됩니다.
+        
+        Args:
+            video_path: 비디오 파일 경로
+            cctv_id: CCTV 식별자
         """
         try:
             cap = cv2.VideoCapture(video_path)
@@ -51,12 +56,13 @@ class VideoProcessingService:
             while True:
                 ret, frame = cap.read()
                 if not ret:
-                    print("Info: Reached end of video or failed to read frame.")
-                    break  # 영상의 끝 또는 프레임 읽기 실패
+                    print(f"Info: 영상이 끝났습니다. CCTV {cctv_id} 영상을 처음부터 다시 재생합니다.")
+                    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)  # 영상을 처음으로 되돌림
+                    continue  # 다음 프레임 읽기 시도
 
                 # YOLO 검증 및 프레임 마킹
                 try:
-                    marked_frame = await process_frame_with_yolo(frame)
+                    marked_frame = await process_frame_with_yolo(frame, cctv_id)
                 except Exception as yolo_err:
                     print(f"Error during YOLO processing: {yolo_err}")
                     # 오류 발생 시 원본 프레임을 전송합니다.

--- a/server/websocket_manager.py
+++ b/server/websocket_manager.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 class StatusMessage(BaseModel):
     status: Literal["dangerous", "normal", "hazardous"]
     description: str
+    cctvId: str  # CCTV 식별자 추가
 
 class UnifiedConnectionManager:
     def __init__(self):
@@ -36,7 +37,13 @@ class UnifiedConnectionManager:
         """Sends a StatusMessage JSON message to all connected clients."""
         disconnected_clients = []
         message_dict = message.model_dump()
-        print(f"Broadcasting message to {len(self.active_connections)} clients: {message_dict}")
+        print("\n=== WebSocket 알림 메시지 ===")
+        print(f"상태: {message_dict['status']}")
+        print(f"CCTV ID: {message_dict['cctvId']}")
+        print(f"설명: {message_dict['description']}")
+        print(f"연결된 클라이언트 수: {len(self.active_connections)}")
+        print("===========================\n")
+        
         connections_to_broadcast = list(self.active_connections)
         for connection in connections_to_broadcast:
             try:


### PR DESCRIPTION
이 PR은 #24 를 통합하여 진행합니다.

related to:
- #24

### 주요 변경 사항: 

### 1. 화재 이벤트 기록 API 구현
- `/api/v1/records` 엔드포인트 추가: 일자별로 그룹화된 화재 이벤트 목록 조회
- `/api/v1/records/{eventId}` 엔드포인트 추가: 특정 이벤트 영상 스트리밍
- 프론트엔드에서는 `baseUrl + thumbnail_url`로 이미지 접근 가능
  - 예: `http://{baseUrl}/static/record/events/event_20240315_142300_thumb.jpg`


### 2. 비디오 스트리밍 로직 중복 제거 
- `frame_generator_with_yolo` 함수에서 video_path 생성 로직 통합
- `lives.py`의 `stream_video_realtime` 함수 간소화
