### PR TITLE
fix: GEMINI_API_KEY 기본값을 환경 변수에서 가져오도록 수정

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
     YOLO_MODEL_PATH: str = "best.pt"
     YOLO_CONFIDENCE_THRESHOLD: float = 0.5
     
-    GEMINI_API_KEY: str
+    GEMINI_API_KEY: str = os.getenv("GEMINI_API_KEY", "")
     SQLALCHEMY_DATABASE_URL: str = "sqlite:///./database.db"
     
     class Config:


### PR DESCRIPTION
## 변경사항

사용자 환경변수로부터 GEMINI_API_KEY를 읽어오는 시점에 기본값을 설정해줍니다.