### PR TITLE
fix: Gemini API 응답의 description 필드 처리 수정

### DIFF
--- a/server/schemas.py
+++ b/server/schemas.py
@@ -67,6 +67,7 @@ class EventSummary(BaseModel):
     address: str
     thumbnail_url: str
     timestamp: datetime
+    description: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/server/services.py
+++ b/server/services.py
@@ -202,6 +202,7 @@ class RecordService:
                     "cctv_name": event.video.cctv_name or event.video.filename,
                     "address": event.video.location or "주소 정보 없음",
                     "timestamp": event.timestamp.isoformat(),
+                    "description": event.analysis or "상세 분석 정보 없음",
                     "thumbnail_url": thumbnail_url
                 })
                 

--- a/server/yolo.py
+++ b/server/yolo.py
@@ -162,7 +162,7 @@ async def fire_alert(current_frame: np.ndarray, cctv_id: str):
         await connection_manager.broadcast_json(
             StatusMessage(
                 status=event_type,
-                description=analysis.get("analysis", ""),
+                description=analysis.get("description", ""),
                 cctvId=cctv_id
             )
         )
@@ -183,7 +183,7 @@ async def fire_alert(current_frame: np.ndarray, cctv_id: str):
                 fps=fps,
                 db=db,
                 video_id=cctv_id,
-                analysis=analysis.get("analysis", ""),
+                analysis=analysis.get("description", ""),
                 event_type=event_type
             )
             


### PR DESCRIPTION
# Gemini API 응답의 description 필드 처리 수정

## 변경사항
- `yolo.py`: Gemini API 응답에서 'analysis' 대신 'description' 필드 사용하도록 수정
- `schemas.py`: EventSummary 모델에 description 필드 추가

## 변경 이유
- Gemini API가 반환하는 응답의 필드명이 'description'인데, 기존 코드에서는 'analysis'로 잘못 참조하고 있었습니다.
- 이로 인해 화재 이벤트의 상세 분석 정보가 API 응답에 포함되지 않는 문제가 있었습니다.


## 변경 결과
이제 API 응답에 description 필드가 정상적으로 포함되어 화재 이벤트의 상세 분석 정보를 확인할 수 있습니다.
<img width="976" alt="스크린샷 2025-05-15 오후 7 27 22" src="https://github.com/user-attachments/assets/832d6542-eba4-4ac5-8010-ac8986e3eae7" />

