### PR TITLE
Feat/alert api

### DIFF
--- a/server/routers/lives.py
+++ b/server/routers/lives.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from database import get_db
 from services import LiveService, VideoProcessingService
-from schemas import LiveResponse
+from schemas import LiveResponse, LiveEvent
 from fastapi.responses import StreamingResponse
 from config import settings
 from models import Video
@@ -51,4 +51,12 @@ async def lives_endpoint(db: Session = Depends(get_db)):
     }
     ```
     """
-    return {"cctvs": LiveService.get_lives(db)} 
+    return {"cctvs": LiveService.get_lives(db)}
+
+@router.get("/{video_id}/latest", response_model=LiveEvent)
+def get_latest_event(video_id: str, db: Session = Depends(get_db)):
+    """특정 CCTV의 가장 최근 화재 이벤트 정보를 반환합니다."""
+    event = LiveService.get_latest_event(db, video_id)
+    if not event:
+        raise HTTPException(status_code=404, detail="최근 이벤트를 찾을 수 없습니다.")
+    return event 

--- a/server/routers/records.py
+++ b/server/routers/records.py
@@ -50,6 +50,7 @@ async def get_records(
               "cctv_name": "강릉시청 앞 CCTV-1",
               "address": "강원도 강릉시",
               "thumbnail_url": "/static/events/evt_001.jpg",
+              "description": "화재 발생",
               "timestamp": "2024-03-15T14:23:00"
             }
           ]
@@ -62,6 +63,7 @@ async def get_records(
               "cctv_name": "강릉시청 앞 CCTV-2",
               "address": "강원도 강릉시",
               "thumbnail_url": "/static/events/evt_002.jpg",
+              "description": "화재 발생",
               "timestamp": "2024-03-14T15:30:00"
             }
           ]

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -87,5 +87,6 @@ class LiveEvent(BaseModel):
     address: str
     timestamp: datetime
     description: Optional[str] = None
+    event_type: str
 
     model_config = ConfigDict(from_attributes=True) 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -78,4 +78,14 @@ class DailyEvents(BaseModel):
 
 class RecordsResponse(BaseModel):
     """화재 이벤트 기록 목록 응답"""
-    records: list[DailyEvents] 
+    records: list[DailyEvents]
+
+class LiveEvent(BaseModel):
+    """CCTV의 최근 화재 이벤트 정보"""
+    eventId: str
+    cctv_name: str
+    address: str
+    timestamp: datetime
+    description: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True) 

--- a/server/schemas.py
+++ b/server/schemas.py
@@ -83,6 +83,7 @@ class RecordsResponse(BaseModel):
 class LiveEvent(BaseModel):
     """CCTV의 최근 화재 이벤트 정보"""
     eventId: str
+    video_id: str
     cctv_name: str
     address: str
     timestamp: datetime

--- a/server/services.py
+++ b/server/services.py
@@ -7,7 +7,7 @@
 # - RecordService: 화재 이벤트 기록을 관리합니다.
 
 import os
-from typing import Any
+from typing import Any, List
 import cv2
 import asyncio
 import numpy as np
@@ -161,8 +161,27 @@ class LiveService:
                 "cctv_name": latest_event.video.cctv_name or latest_event.video.filename,
                 "address": latest_event.video.location or "주소 정보 없음",
                 "timestamp": latest_event.timestamp.isoformat(),
-                "description": latest_event.analysis or "상세 분석 정보 없음"
+                "description": latest_event.analysis if latest_event.analysis else "화재 감지됨",
+                "event_type": latest_event.event_type
             }
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"최근 이벤트 조회 중 오류 발생: {str(e)}")
+
+    @staticmethod
+    def get_all_latest_events(db: Session) -> List[dict]:
+        """모든 CCTV의 가장 최근 화재 이벤트를 반환합니다."""
+        try:
+            # 모든 활성화된 CCTV 조회
+            videos = db.query(Video).filter(Video.status == "active").all()
+            
+            # 각 CCTV별 최근 이벤트 조회
+            latest_events = []
+            for video in videos:
+                event = LiveService.get_latest_event(db, video.id)
+                if event:
+                    latest_events.append(event)
+            
+            return latest_events
         except Exception as e:
             raise HTTPException(status_code=500, detail=f"최근 이벤트 조회 중 오류 발생: {str(e)}")
 

--- a/server/services.py
+++ b/server/services.py
@@ -142,6 +142,31 @@ class LiveService:
     """실시간 CCTV 스트리밍 가능 목록 제공"""
 
     @staticmethod
+    def get_latest_event(db: Session, video_id: str) -> dict:
+        """특정 CCTV의 가장 최근 화재 이벤트를 반환합니다."""
+        try:
+            # 해당 CCTV의 가장 최근 이벤트 조회
+            latest_event = (
+                db.query(FireEvent)
+                .filter(FireEvent.video_id == video_id)
+                .order_by(FireEvent.timestamp.desc())
+                .first()
+            )
+
+            if not latest_event:
+                return None
+
+            return {
+                "eventId": f"evt_{latest_event.id:03d}",
+                "cctv_name": latest_event.video.cctv_name or latest_event.video.filename,
+                "address": latest_event.video.location or "주소 정보 없음",
+                "timestamp": latest_event.timestamp.isoformat(),
+                "description": latest_event.analysis or "상세 분석 정보 없음"
+            }
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"최근 이벤트 조회 중 오류 발생: {str(e)}")
+
+    @staticmethod
     def get_lives(db: Session):
         """
         DB에서 실시간 스트리밍 가능한 CCTV 목록을 조회합니다.

--- a/server/services.py
+++ b/server/services.py
@@ -158,6 +158,7 @@ class LiveService:
 
             return {
                 "eventId": f"evt_{latest_event.id:03d}",
+                "video_id": latest_event.video_id,
                 "cctv_name": latest_event.video.cctv_name or latest_event.video.filename,
                 "address": latest_event.video.location or "주소 정보 없음",
                 "timestamp": latest_event.timestamp.isoformat(),


### PR DESCRIPTION
### 주요 변경 사항 
- 웹소켓 알림 외에도 API를 통한 이벤트 정보 조회 기능 필요
- 클라이언트에서 주기적으로 각 CCTV의 최근 이벤트 상태를 확인할 수 있도록 함
 

### API
### `/api/v1/lives/latest`
- 모든 CCTV의 최근 화재 이벤트를 조회하는 API
- 각 CCTV별로 가장 최근 이벤트를 배열로 반환
- 이벤트가 없는 CCTV는 제외

응답 예시:
```json
[
  {
    "eventId": "evt_007",
    "video_id": "video_001",
    "cctv_name": "강릉시청 앞 CCTV-1",
    "address": "강원도 강릉시",
    "timestamp": "2025-05-16T04:59:25.957505",
    "description": "Small fire with smoke on the ground near a roadway.  The fire appears to be contained to a small area.",
    "event_type": "hazardous"
  },
  {
    "eventId": "evt_002",
    "video_id": "video_002",
    "cctv_name": "강릉시청 앞 CCTV-2",
    "address": "강원도 강릉시",
    "timestamp": "2025-05-16T04:45:08.921896",
    "description": "Aerial view showing a small plume of smoke rising from a wooded area near a road and parking lot.  The source of the smoke is unclear but warrants investigation.",
    "event_type": "hazardous"
  }
]
```


### `/api/v1/lives/{videoId}/latest`
- CCTV별로 저장된 이벤트 중 가장 최근 이벤트를 조회하는 API
- timestamp 기준으로 내림차순 정렬하여 가장 최근 이벤트 반환
- 이벤트가 없는 경우 404 응답

응답 예시:
```json
{
  "eventId": "evt_007",
  "video_id": "video_001",
  "cctv_name": "강릉시청 앞 CCTV-1",
  "address": "강원도 강릉시",
  "timestamp": "2025-05-16T04:59:25.957505",
  "description": "Small fire with smoke on the ground near a roadway.  The fire appears to be contained to a small area.",
  "event_type": "hazardous"
}
```


